### PR TITLE
GH-56: Use slash command as the default one

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,8 +1,8 @@
 {
   "token": "YOUR_BOT_USER_TOKEN",
   "language": "en",
-  "command": "!ttt",
-  "slashCommand": "tictactoe",
+  "command": "tictactoe",
+  "textCommand": "!ttt",
   "allowedChannelIds": [],
   "allowedRoleIds": [],
   "requestExpireTime": 60,

--- a/src/bot/TicTacToeBot.ts
+++ b/src/bot/TicTacToeBot.ts
@@ -62,17 +62,17 @@ export default class TicTacToeBot {
      */
     public attachToClient(client: Client): void {
         // Handle slash command if enabled
-        if (this.configuration.slashCommand) {
+        if (this.configuration.command) {
             const register = new AppCommandRegister(
                 client.application!.commands,
-                this.configuration.slashCommand
+                this.configuration.command
             );
             client.on('messageCreate', register.handleDeployMessage.bind(register));
             client.on('interactionCreate', this.command.handleInteraction.bind(this.command));
         }
 
         // Handle text command if enabled
-        if (this.configuration.command) {
+        if (this.configuration.textCommand) {
             client.on('messageCreate', this.command.handleMessage.bind(this.command));
         }
     }

--- a/src/bot/command/GameCommand.ts
+++ b/src/bot/command/GameCommand.ts
@@ -45,7 +45,8 @@ export default class GameCommand {
             message.member &&
             !message.author.bot &&
             message.channel instanceof TextChannel &&
-            (noTrigger || (this.config.command && message.content.startsWith(this.config.command)))
+            (noTrigger ||
+                (this.config.textCommand && message.content.startsWith(this.config.textCommand)))
         ) {
             const tunnel = new TextMessagingTunnel(message);
             const invited = message.mentions.members?.first();
@@ -65,7 +66,7 @@ export default class GameCommand {
             interaction instanceof CommandInteraction &&
             interaction.channel instanceof TextChannel &&
             interaction.member instanceof GuildMember &&
-            (noTrigger || interaction.commandName === this.config.slashCommand)
+            (noTrigger || interaction.commandName === this.config.command)
         ) {
             // Retrieve the inviter and create an interaction tunnel
             const tunnnel = new InteractionMessagingTunnel(interaction);

--- a/src/config/CommandConfig.ts
+++ b/src/config/CommandConfig.ts
@@ -6,11 +6,11 @@
  */
 export default interface CommandConfig {
     /**
-     * Text command used to start a new game.
+     * Slash command used to start a new game.
      */
     command?: string;
     /**
-     * Slash command used to start a new game.
+     * Text command used to start a new game.
      */
-    slashCommand?: string;
+    textCommand?: string;
 }

--- a/src/config/ConfigProvider.ts
+++ b/src/config/ConfigProvider.ts
@@ -13,8 +13,8 @@ export default class ConfigProvider implements Config {
     public token = '';
     public language = 'en';
 
-    public command = '!ttt';
-    public slashCommand = undefined;
+    public command = 'tictactoe';
+    public textCommand = undefined;
 
     public allowedChannelIds = [];
     public allowedRoleIds = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,8 +49,8 @@ class TicTacToe {
 
         if (!loginToken) {
             throw new Error('Bot token needed to start Discord client.');
-        } else if (!this.config.command && !this.config.slashCommand) {
-            throw new Error('Game text or slash command needed to start Discord client.');
+        } else if (!this.config.command && !this.config.textCommand) {
+            throw new Error('Game slash or text command needed to start Discord client.');
         }
 
         const client = new Client({


### PR DESCRIPTION
As part of the issue #56, starting from **v3** of the module, slash commands will become the default option and text commands the legacy one. **Both options will remain available (even simultaneously) as long as they are used. So there is no reason for the text command to be removed at this time.**

This PR brings this behavior into the module and switches the two command types.