### PR TITLE
GH-51: Play using Discord buttons

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -9,6 +9,7 @@
   "requestCooldownTime": 0,
   "simultaneousGames": false,
   "gameExpireTime": 30,
+  "gameBoardButtons": false,
   "gameBoardDelete": false,
   "gameBoardEmojies": []
 }

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -9,7 +9,7 @@
   "requestCooldownTime": 0,
   "simultaneousGames": false,
   "gameExpireTime": 30,
-  "gameBoardButtons": false,
+  "gameBoardReactions": false,
   "gameBoardDelete": false,
   "gameBoardEmojies": []
 }

--- a/src/__tests__/GameBoardBuilder.test.ts
+++ b/src/__tests__/GameBoardBuilder.test.ts
@@ -17,24 +17,31 @@ describe('GameBoardBuilder', () => {
     });
 
     it('should send empty message by default', () => {
-        expect(builder.toString()).toBe('');
+        expect(builder.toMessageOptions()).toEqual({ content: '', components: [] });
     });
 
     it('should compute title based on entity names', () => {
         builder.withTitle({ id: '1', displayName: 'entity1' }, { id: '2', displayName: 'entity2' });
-        expect(builder.toString()).toBe(':game_die: `entity1` **VS** `entity2`\n\n');
+        expect(builder.toMessageOptions()).toEqual({
+            content: ':game_die: `entity1` **VS** `entity2`\n\n',
+            components: []
+        });
     });
 
     it('should compute board using custom emojies', () => {
         builder
             .withEmojies(':dog:', ':cat:')
             .withBoard(2, [Player.First, Player.Second, Player.Second, Player.First]);
-        expect(builder.toString()).toBe(':dog: :cat: \n:cat: :dog: \n');
+
+        expect(builder.toMessageOptions()).toEqual({
+            content: ':dog: :cat: \n:cat: :dog: \n',
+            components: []
+        });
     });
 
     it('should add an empty line between board and state if both defined', () => {
         builder.withBoard(1, [Player.None]).withEntityPlaying();
-        expect(builder.toString()).toContain('\n');
+        expect(builder.toMessageOptions().content).toContain('\n');
     });
 
     it.each`
@@ -44,7 +51,7 @@ describe('GameBoardBuilder', () => {
         ${{ toString: () => 'fake' }} | ${'fake, select your move:'}
     `('should set state based if playing entity is $entity', ({ entity, state }) => {
         builder.withEntityPlaying(entity);
-        expect(builder.toString()).toBe(state);
+        expect(builder.toMessageOptions()).toEqual({ content: state, components: [] });
     });
 
     it.each`
@@ -53,6 +60,6 @@ describe('GameBoardBuilder', () => {
         ${{ toString: () => 'fake' }} | ${':tada: fake has won the game!'}
     `('should set state based if winning entity is $entity', ({ entity, state }) => {
         builder.withEndingMessage(entity);
-        expect(builder.toString()).toBe(state);
+        expect(builder.toMessageOptions()).toEqual({ content: state, components: [] });
     });
 });

--- a/src/__tests__/GameBoardButtonBuilder.test.ts
+++ b/src/__tests__/GameBoardButtonBuilder.test.ts
@@ -1,0 +1,59 @@
+import GameBoardButtonBuilder from '@bot/entity/GameBoardButtonBuilder';
+import localize from '@i18n/localize';
+import AI from '@tictactoe/AI';
+import { Player } from '@tictactoe/Player';
+import { MessageButton } from 'discord.js';
+
+jest.mock('@tictactoe/AI');
+
+describe('GameBoardButtonBuilder', () => {
+    let builder: GameBoardButtonBuilder;
+
+    beforeAll(() => {
+        localize.loadFromLocale('en');
+    });
+
+    beforeEach(() => {
+        builder = new GameBoardButtonBuilder();
+    });
+
+    it('should send empty message by default', () => {
+        expect(builder.toMessageOptions()).toEqual({ content: '', components: [] });
+    });
+
+    it('should compute board components', () => {
+        const options = builder
+            .withBoard(2, [Player.First, Player.None, Player.None, Player.Second])
+            .toMessageOptions();
+
+        expect(options.components).toHaveLength(2);
+        expect(options.components![0].components).toHaveLength(2);
+        expect(options.components![1].components).toHaveLength(2);
+        expect((options.components![0].components[0] as MessageButton).label).toBe('X');
+        expect((options.components![0].components[1] as MessageButton).label).toBe(' ');
+        expect((options.components![1].components[0] as MessageButton).label).toBe(' ');
+        expect((options.components![1].components[1] as MessageButton).label).toBe('O');
+    });
+
+    it('should compute board using custom emojies', () => {
+        const options = builder
+            .withEmojies(':dog:', ':cat:')
+            .withBoard(2, [Player.First, Player.Second, Player.Second, Player.First])
+            .toMessageOptions();
+
+        expect((options.components![0].components[0] as MessageButton).emoji?.name).toBe('dog');
+        expect((options.components![0].components[1] as MessageButton).emoji?.name).toBe('cat');
+        expect((options.components![1].components[0] as MessageButton).emoji?.name).toBe('cat');
+        expect((options.components![1].components[1] as MessageButton).emoji?.name).toBe('dog');
+    });
+
+    it.each`
+        entity                        | state
+        ${undefined}                  | ${''}
+        ${new AI()}                   | ${':robot: AI is playing, please wait...'}
+        ${{ toString: () => 'fake' }} | ${'fake, select your move:'}
+    `('should set state based if playing entity is $entity', ({ entity, state }) => {
+        builder.withEntityPlaying(entity);
+        expect(builder.toMessageOptions()).toEqual({ content: state, components: [] });
+    });
+});

--- a/src/bot/entity/DuelRequest.ts
+++ b/src/bot/entity/DuelRequest.ts
@@ -118,9 +118,11 @@ export default class DuelRequest {
             await this.tunnel.end();
             await this.manager.createGame(this.tunnel, this.invited);
         } else {
-            await this.tunnel.end(
-                localize.__('duel.reject', { invited: formatDiscordName(this.invited.displayName) })
-            );
+            await this.tunnel.end({
+                content: localize.__('duel.reject', {
+                    invited: formatDiscordName(this.invited.displayName)
+                })
+            });
         }
     }
 
@@ -128,8 +130,10 @@ export default class DuelRequest {
      * Called if the challenge has expired without answer.
      */
     private async challengeExpired(): Promise<void> {
-        await this.tunnel.end(
-            localize.__('duel.expire', { invited: formatDiscordName(this.invited.displayName) })
-        );
+        await this.tunnel.end({
+            content: localize.__('duel.expire', {
+                invited: formatDiscordName(this.invited.displayName)
+            })
+        });
     }
 }

--- a/src/bot/entity/GameBoard.ts
+++ b/src/bot/entity/GameBoard.ts
@@ -1,4 +1,5 @@
 import GameBoardBuilder from '@bot/entity/GameBoardBuilder';
+import GameBoardButtonBuilder from '@bot/entity/GameBoardButtonBuilder';
 import MessagingTunnel from '@bot/messaging/MessagingTunnel';
 import GameStateManager from '@bot/state/GameStateManager';
 import GameConfig from '@config/GameConfig';
@@ -6,7 +7,14 @@ import localize from '@i18n/localize';
 import AI from '@tictactoe/AI';
 import Entity from '@tictactoe/Entity';
 import Game from '@tictactoe/Game';
-import { Collection, Message, MessageOptions, MessageReaction, Snowflake } from 'discord.js';
+import {
+    ButtonInteraction,
+    Collection,
+    Message,
+    MessageOptions,
+    MessageReaction,
+    Snowflake
+} from 'discord.js';
 
 /**
  * Message sent to display the status of a game board.
@@ -79,7 +87,11 @@ export default class GameBoard {
      * Creates or retrieves message of the gameboard.
      */
     public get content(): MessageOptions {
-        const builder = new GameBoardBuilder()
+        const builder = this.configuration.gameBoardButtons
+            ? new GameBoardButtonBuilder()
+            : new GameBoardBuilder();
+
+        builder
             .withTitle(this.entities[0], this.entities[1])
             .withBoard(this.game.boardSize, this.game.board)
             .withEntityPlaying(
@@ -95,7 +107,7 @@ export default class GameBoard {
             builder.withEmojies(emojies[0], emojies[1]);
         }
 
-        return { content: builder.toString() };
+        return builder.toMessageOptions();
     }
 
     /**
@@ -110,18 +122,31 @@ export default class GameBoard {
     }
 
     /**
+     * Converts a button identifier to a move position (from 0 to 8).
+     * If the move is not valid, returns -1.
+     *
+     * @param identifier button identifier
+     * @private
+     */
+    private static buttonIdentifierToMove(identifier: string): number {
+        return parseInt(identifier) ?? -1;
+    }
+
+    /**
      * Attachs the duel request to a specific message
      * and reacts to it in order to get processed.
      *
      * @param message discord.js message object to attach
      */
     public async attachTo(message: Message): Promise<void> {
-        for (const reaction of GameBoardBuilder.MOVE_REACTIONS) {
-            try {
-                await message.react(reaction);
-            } catch {
-                await this.onExpire();
-                return;
+        if (!this.configuration.gameBoardButtons) {
+            for (const reaction of GameBoardBuilder.MOVE_REACTIONS) {
+                try {
+                    await message.react(reaction);
+                } catch {
+                    await this.onExpire();
+                    return;
+                }
             }
         }
 
@@ -149,8 +174,12 @@ export default class GameBoard {
     /**
      * Updates the message.
      */
-    public async update(): Promise<void> {
-        return this.tunnel.editReply(this.content);
+    public async update(interaction?: ButtonInteraction): Promise<void> {
+        if (interaction) {
+            await interaction.update(this.content);
+        } else {
+            return this.tunnel.editReply(this.content);
+        }
     }
 
     /**
@@ -169,9 +198,22 @@ export default class GameBoard {
      * @param collected collected data from discordjs
      * @private
      */
-    private async onMoveSelected(collected: Collection<Snowflake, MessageReaction>): Promise<void> {
+    private async onEmojiMoveSelected(
+        collected: Collection<Snowflake, MessageReaction>
+    ): Promise<void> {
         const move = GameBoardBuilder.MOVE_REACTIONS.indexOf(collected.first()!.emoji.name!);
         await this.playTurn(move);
+    }
+
+    /**
+     * Called when a player has selected a valid move button.
+     *
+     * @param collected collected data from discordjs
+     * @private
+     */
+    private async onButtonMoveSelected(interaction: ButtonInteraction): Promise<void> {
+        const move = GameBoard.buttonIdentifierToMove(interaction.customId);
+        return await this.playTurn(move, interaction);
     }
 
     /**
@@ -180,23 +222,25 @@ export default class GameBoard {
      * @param move move to play for the current player
      * @private
      */
-    private async playTurn(move: number): Promise<void> {
+    private async playTurn(move: number, interaction?: ButtonInteraction): Promise<void> {
         this.game.updateBoard(this.game.currentPlayer, move);
 
         if (this.game.finished) {
             const winner = this.getEntity(this.game.winner);
 
             if (this.configuration.gameBoardDelete) {
-                await this.tunnel.end(new GameBoardBuilder().withEndingMessage(winner).toString());
+                await this.tunnel.end(
+                    new GameBoardBuilder().withEndingMessage(winner).toMessageOptions()
+                );
             } else {
                 await this.tunnel.reply?.reactions?.removeAll();
-                await this.update();
+                await this.update(interaction);
             }
 
             this.manager.endGame(this, winner ?? null);
         } else {
             this.game.nextPlayer();
-            await this.update();
+            await this.update(interaction);
             await this.attemptNextTurn();
         }
     }
@@ -206,7 +250,7 @@ export default class GameBoard {
      * @private
      */
     private async onExpire(): Promise<void> {
-        await this.tunnel.end(localize.__('game.expire'));
+        await this.tunnel.end({ content: localize.__('game.expire'), components: [] });
         this.manager.endGame(this);
     }
 
@@ -215,19 +259,41 @@ export default class GameBoard {
      * @private
      */
     private awaitMove(): void {
-        const expireTime = this.configuration.gameExpireTime ?? 30;
+        const expireTime = (this.configuration.gameExpireTime ?? 30) * 1000;
         if (!this.tunnel.reply || this.tunnel.reply.deleted) return;
-        this.tunnel.reply
-            .awaitReactions({
-                filter: (reaction, user) =>
-                    reaction.emoji.name != null &&
-                    user.id === this.getEntity(this.game.currentPlayer)?.id &&
-                    this.game.isMoveValid(GameBoard.reactionToMove(reaction.emoji.name)),
-                max: 1,
-                time: expireTime * 1000,
-                errors: ['time']
-            })
-            .then(this.onMoveSelected.bind(this))
-            .catch(this.onExpire.bind(this));
+
+        const currentEntity = this.getEntity(this.game.currentPlayer)?.id;
+
+        if (this.configuration.gameBoardButtons) {
+            this.tunnel.reply
+                .createMessageComponentCollector({
+                    filter: interaction =>
+                        interaction.user.id === currentEntity &&
+                        this.game.isMoveValid(
+                            GameBoard.buttonIdentifierToMove(interaction.customId)
+                        ),
+                    max: 1,
+                    time: expireTime
+                })
+                .on('collect', this.onButtonMoveSelected.bind(this))
+                .on('end', async (_, reason) => {
+                    if (reason === 'time') {
+                        await this.onExpire();
+                    }
+                });
+        } else {
+            this.tunnel.reply
+                .awaitReactions({
+                    filter: (reaction, user) =>
+                        reaction.emoji.name != null &&
+                        user.id === currentEntity &&
+                        this.game.isMoveValid(GameBoard.reactionToMove(reaction.emoji.name)),
+                    max: 1,
+                    time: expireTime,
+                    errors: ['time']
+                })
+                .then(this.onEmojiMoveSelected.bind(this))
+                .catch(this.onExpire.bind(this));
+        }
     }
 }

--- a/src/bot/entity/GameBoard.ts
+++ b/src/bot/entity/GameBoard.ts
@@ -214,7 +214,7 @@ export default class GameBoard {
      */
     private async onButtonMoveSelected(interaction: ButtonInteraction): Promise<void> {
         const move = GameBoard.buttonIdentifierToMove(interaction.customId);
-        return await this.playTurn(move, interaction);
+        return this.playTurn(move, interaction);
     }
 
     /**

--- a/src/bot/entity/GameBoard.ts
+++ b/src/bot/entity/GameBoard.ts
@@ -174,10 +174,12 @@ export default class GameBoard {
 
     /**
      * Updates the message.
+     *
+     * @param interaction interaction to update if action was triggered by it
      */
     public async update(interaction?: ButtonInteraction): Promise<void> {
         if (interaction) {
-            await interaction.update(this.content);
+            return interaction.update(this.content);
         } else {
             return this.tunnel.editReply(this.content);
         }
@@ -203,7 +205,7 @@ export default class GameBoard {
         collected: Collection<Snowflake, MessageReaction>
     ): Promise<void> {
         const move = GameBoardBuilder.MOVE_REACTIONS.indexOf(collected.first()!.emoji.name!);
-        await this.playTurn(move);
+        return this.playTurn(move);
     }
 
     /**
@@ -221,6 +223,7 @@ export default class GameBoard {
      * Play the current player's turn with a specific move.
      *
      * @param move move to play for the current player
+     * @param interaction interaction to update if action was triggered by it
      * @private
      */
     private async playTurn(move: number, interaction?: ButtonInteraction): Promise<void> {

--- a/src/bot/entity/GameBoardBuilder.ts
+++ b/src/bot/entity/GameBoardBuilder.ts
@@ -3,10 +3,11 @@ import localize from '@i18n/localize';
 import AI from '@tictactoe/AI';
 import Entity from '@tictactoe/Entity';
 import { Player } from '@tictactoe/Player';
+import { MessageOptions } from 'discord.js';
 
 /**
- * Builds string representation of a game board
- * whiches will be displayed as a Discord message.
+ * Builds representation of a game board using text emojis
+ * whiches will be displayed in a Discord message.
  *
  * @author Utarwyn
  * @since 2.1.0
@@ -18,29 +19,29 @@ export default class GameBoardBuilder {
     public static readonly MOVE_REACTIONS = ['↖️', '⬆️', '↗️', '⬅️', '⏺️', '➡️', '↙️', '⬇️', '↘️'];
     /**
      * Unicode emojis used for representing the two players.
-     * @private
+     * @protected
      */
-    private emojies = ['⬜', '🇽', '🅾️'];
+    protected emojies = ['⬜', '🇽', '🅾️'];
     /**
      * Stores game board title message.
-     * @private
+     * @protected
      */
-    private title: string;
+    protected title: string;
     /**
      * Stores game current state.
-     * @private
+     * @protected
      */
-    private state: string;
+    protected state: string;
     /**
      * Stores game board size.
-     * @private
+     * @protected
      */
-    private boardSize: number;
+    protected boardSize: number;
     /**
      * Stores game board data.
-     * @private
+     * @protected
      */
-    private boardData: Player[];
+    protected boardData: Player[];
 
     /**
      * Constructs a new game board builder.
@@ -127,9 +128,11 @@ export default class GameBoardBuilder {
     }
 
     /**
-     * Constructs final string representation of the game board.
+     * Constructs final representation of the game board.
+     *
+     * @returns message options of the gameboard
      */
-    toString(): string {
+    toMessageOptions(): MessageOptions {
         // Generate string representation of the board
         let board = '';
 
@@ -142,6 +145,6 @@ export default class GameBoardBuilder {
 
         // Generate final string
         const state = this.state && board ? '\n' + this.state : this.state;
-        return this.title + board + state;
+        return { content: this.title + board + state, components: [] };
     }
 }

--- a/src/bot/entity/GameBoardButtonBuilder.ts
+++ b/src/bot/entity/GameBoardButtonBuilder.ts
@@ -1,0 +1,96 @@
+import GameBoardBuilder from '@bot/entity/GameBoardBuilder';
+import Entity from '@tictactoe/Entity';
+import { Player } from '@tictactoe/Player';
+import {
+    MessageActionRow,
+    MessageButton,
+    MessageButtonStyleResolvable,
+    MessageOptions
+} from 'discord.js';
+
+/**
+ * Builds representation of a game board using buttons
+ * whiches will be displayed in a Discord message.
+ *
+ * @author Utarwyn
+ * @since 3.0.0
+ */
+export default class GameBoardButtonBuilder extends GameBoardBuilder {
+    /**
+     * Default labels used on buttons if emojies are not enabled.
+     * @protected
+     */
+    private buttonLabels = ['X', 'O'];
+    /**
+     * Button styles used for representing the two players.
+     * @private
+     */
+    private buttonStyles: MessageButtonStyleResolvable[] = ['SECONDARY', 'PRIMARY', 'DANGER'];
+    /**
+     * Stores if emojies have been customized.
+     * @private
+     */
+    private customEmojies = false;
+
+    /**
+     * @inheritdoc
+     * @override
+     */
+    withEntityPlaying(entity?: Entity): GameBoardBuilder {
+        // Do not display state if game is loading
+        if (entity) {
+            return super.withEntityPlaying(entity);
+        } else {
+            return this;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     * @override
+     */
+    override withEmojies(first: string, second: string): GameBoardBuilder {
+        this.customEmojies = true;
+        return super.withEmojies(first, second);
+    }
+
+    /**
+     * @inheritdoc
+     * @override
+     */
+    override toMessageOptions(): MessageOptions {
+        return {
+            content: this.title + this.state,
+            components: [...Array(this.boardSize).keys()].map(row =>
+                new MessageActionRow().addComponents(
+                    [...Array(this.boardSize).keys()].map(col => this.createButton(row, col))
+                )
+            )
+        };
+    }
+
+    /**
+     * Creates a button to be displayed based on current game context.
+     *
+     * @param row button placement row
+     * @param col button placement column
+     * @returns button discord.js object
+     */
+    private createButton(row: number, col: number): MessageButton {
+        const button = new MessageButton();
+        const buttonIndex = row * this.boardSize + col;
+        const buttonData = this.boardData[buttonIndex];
+
+        if (buttonData !== Player.None) {
+            if (this.customEmojies) {
+                button.setEmoji(this.emojies[buttonData]);
+            } else {
+                button.setLabel(this.buttonLabels[buttonData - 1]);
+            }
+        } else {
+            button.setLabel(' ');
+        }
+
+        return button.setCustomId(buttonIndex.toString()).setStyle(this.buttonStyles[buttonData]);
+    }
+}

--- a/src/bot/entity/GameBoardButtonBuilder.ts
+++ b/src/bot/entity/GameBoardButtonBuilder.ts
@@ -36,7 +36,7 @@ export default class GameBoardButtonBuilder extends GameBoardBuilder {
      * @inheritdoc
      * @override
      */
-    withEntityPlaying(entity?: Entity): GameBoardBuilder {
+    override withEntityPlaying(entity?: Entity): GameBoardBuilder {
         // Do not display state if game is loading
         if (entity) {
             return super.withEntityPlaying(entity);

--- a/src/bot/messaging/InteractionMessagingTunnel.ts
+++ b/src/bot/messaging/InteractionMessagingTunnel.ts
@@ -82,10 +82,10 @@ export default class InteractionMessagingTunnel extends MessagingTunnel {
     /**
      * @inheritdoc
      */
-    public async end(reason?: string): Promise<void> {
+    public async end(reason?: MessagingAnswer): Promise<void> {
         if (this.reply) {
             try {
-                await this.editReply({ content: reason ?? '.' });
+                await this.editReply(reason ?? { content: '.' });
                 await this.reply.suppressEmbeds(true);
                 await this.reply.reactions.removeAll();
             } catch {

--- a/src/bot/messaging/MessagingTunnel.ts
+++ b/src/bot/messaging/MessagingTunnel.ts
@@ -53,5 +53,5 @@ export default abstract class MessagingTunnel {
      *
      * @param reason reason of the tunnel ending
      */
-    public abstract end(reason?: string): Promise<void>;
+    public abstract end(reason?: MessagingAnswer): Promise<void>;
 }

--- a/src/bot/messaging/TextMessagingTunnel.ts
+++ b/src/bot/messaging/TextMessagingTunnel.ts
@@ -75,7 +75,7 @@ export default class TextMessagingTunnel extends MessagingTunnel {
     /**
      * @inheritdoc
      */
-    public async end(reason?: string): Promise<void> {
+    public async end(reason?: MessagingAnswer): Promise<void> {
         if (this.reply) {
             if (this.reply.deletable && !this.reply.deleted) {
                 try {

--- a/src/config/ConfigProvider.ts
+++ b/src/config/ConfigProvider.ts
@@ -23,7 +23,7 @@ export default class ConfigProvider implements Config {
     public simultaneousGames = false;
 
     public gameExpireTime = 30;
-    public gameBoardButtons = false;
+    public gameBoardReactions = false;
     public gameBoardDelete = false;
     public gameBoardEmojies = [];
 

--- a/src/config/ConfigProvider.ts
+++ b/src/config/ConfigProvider.ts
@@ -23,6 +23,7 @@ export default class ConfigProvider implements Config {
     public simultaneousGames = false;
 
     public gameExpireTime = 30;
+    public gameBoardButtons = false;
     public gameBoardDelete = false;
     public gameBoardEmojies = [];
 

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -10,6 +10,10 @@ export default interface GameConfig {
      */
     gameExpireTime?: number;
     /**
+     * Display gameboard using buttons instead of emojies with reactions.
+     */
+    gameBoardButtons?: boolean;
+    /**
      * Should bot needs to delete the game board message.
      */
     gameBoardDelete?: boolean;

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -10,9 +10,9 @@ export default interface GameConfig {
      */
     gameExpireTime?: number;
     /**
-     * Display gameboard using buttons instead of emojies with reactions.
+     * Interact with gameboard using reactions instead of buttons.
      */
-    gameBoardButtons?: boolean;
+    gameBoardReactions?: boolean;
     /**
      * Should bot needs to delete the game board message.
      */


### PR DESCRIPTION
## Description
A recent Discord feature allows us to use buttons in addition of reactions to interact with messages.
**The main idea of that PR is to use buttons instead of reactions to handle tic-tac-toe gameboards**, as described in issue #51.

Keep in mind that although buttons will be the default choice, you can still use reactions by setting a configuration value. See below for more information on this. Also, custom emojies are applied to buttons if defined in the config. Gameboard using buttons is also deleted after a game if specific config value is enabled.

#### Here is a preview of how it looks using a slash command:
![image](https://user-images.githubusercontent.com/9255967/150703859-c62eb5c8-709f-4f9c-83f2-2d711428822b.png)

#### Here is how to disable it (and come back to reactions):
```json
{
    "gameBoardReactions": true
}
```

🌂Closes #51 
🚀 Will be available from **v3.0.x**.