### PR TITLE
GH-56: Customize option name for slash command

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -3,6 +3,7 @@
   "language": "en",
   "command": "!ttt",
   "slashCommand": "tictactoe",
+  "slashCommandOptionName": "opponent",
   "allowedChannelIds": [],
   "allowedRoleIds": [],
   "requestExpireTime": 60,

--- a/src/bot/TicTacToeBot.ts
+++ b/src/bot/TicTacToeBot.ts
@@ -63,7 +63,11 @@ export default class TicTacToeBot {
     public attachToClient(client: Client): void {
         // Handle slash command if enabled
         if (this.configuration.slashCommand) {
-            const register = new AppCommandRegister(client, this.configuration.slashCommand);
+            const register = new AppCommandRegister(
+                client,
+                this.configuration.slashCommand,
+                this.configuration.slashCommandOptionName ?? 'opponent'
+            );
             client.on('message', register.handleDeployMessage.bind(register));
             client.ws.on('INTERACTION_CREATE' as WSEventType, interaction =>
                 this.command.handleInteraction(client, interaction)

--- a/src/bot/command/AppCommandRegister.ts
+++ b/src/bot/command/AppCommandRegister.ts
@@ -14,20 +14,27 @@ export default class AppCommandRegister {
      */
     private readonly client: Client;
     /**
-     * Name of the application command to rregister
+     * Name of the application command to register
      * @private
      */
     private readonly name: string;
+    /**
+     * Name of the option to mention another user
+     * @private
+     */
+    private readonly optionName: string;
 
     /**
      * Constructs application command registration handler.
      *
      * @param client discord.js client instance
      * @param name application name to register
+     * @param optionName name of the option to mention another user
      */
-    constructor(client: Client, name: string) {
+    constructor(client: Client, name: string, optionName: string) {
         this.client = client;
         this.name = name;
+        this.optionName = optionName;
     }
 
     /**
@@ -69,7 +76,7 @@ export default class AppCommandRegister {
                     options: [
                         {
                             type: 6,
-                            name: 'opponent',
+                            name: this.optionName,
                             description: localize.__('command.option-user')
                         }
                     ]

--- a/src/config/CommandConfig.ts
+++ b/src/config/CommandConfig.ts
@@ -13,4 +13,8 @@ export default interface CommandConfig {
      * Slash command used to start a new game.
      */
     slashCommand?: string;
+    /**
+     * Name of slash command option to request a duel against another user.
+     */
+    slashCommandOptionName?: string;
 }

--- a/src/config/ConfigProvider.ts
+++ b/src/config/ConfigProvider.ts
@@ -15,6 +15,7 @@ export default class ConfigProvider implements Config {
 
     public command = '!ttt';
     public slashCommand = undefined;
+    public slashCommandOptionName = 'opponent';
 
     public allowedChannelIds = [];
     public allowedRoleIds = [];


### PR DESCRIPTION
## Description
Using slash command is now supported in the module. In the first version I used `opponent` as the option to provide the name of an user to play with. It seems legit to provide you a way to customize this name and put your own if wanted.

This PR brings that support. **You must reload your command using `?tttdeploy` after each change**.

### New configuration option

| Module versionning | Option name                         |
| ---------------------- | ------------------------------- |
| v3.x.x                        | commandOptionName          |
| v2.2.x                        | slashCommandOptionName |

### Example

#### Here is an example on how to rename it `player` using v2.2.x:
```json
{
    "slashCommandOptionName": "player"
}
```

#### And how it looks after deployed:
![image](https://user-images.githubusercontent.com/9255967/150861693-01d43a53-0a73-4b46-8b20-119c351f812e.png)

🌂Closes #56 
🚀 Will be available from **v2.2.x** and **v3.0.0**.