### PR TITLE
Update GameStateValidator.ts

### DIFF
--- a/src/bot/state/GameStateValidator.ts
+++ b/src/bot/state/GameStateValidator.ts
@@ -17,11 +17,10 @@ export default class GameStateValidator {
      */
     private static readonly PERM_LIST: PermissionString[] = [
         'ADD_REACTIONS',
-        'MANAGE_MESSAGES',
         'READ_MESSAGE_HISTORY',
         'SEND_MESSAGES',
         'VIEW_CHANNEL'
-    ];
+    ]; // bot doesn't need manage message to delete its own message
 
     /**
      * Stores configuration of the module.


### PR DESCRIPTION
Bot doesn't need "Manage Message" permission to delete its own message.