### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/i18n/I18nProvider.ts
+++ b/src/i18n/I18nProvider.ts
@@ -50,7 +50,7 @@ export class I18nProvider {
         if (!loaded && locale && locale.startsWith(I18nProvider.FILEPATH_PREFIX)) {
             filepath = path.resolve(
                 process.cwd(),
-                locale.substr(I18nProvider.FILEPATH_PREFIX.length)
+                locale.slice(I18nProvider.FILEPATH_PREFIX.length)
             );
         }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.