### PR TITLE
Configurable level of difficulty of AI algorithm

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -11,6 +11,7 @@
   "requestExpireTime": 60,
   "requestReactions": false,
   "simultaneousGames": false,
+  "aiDifficulty": "Medium",
   "gameExpireTime": 30,
   "gameBoardReactions": false,
   "gameBoardDelete": false,

--- a/src/__tests__/AI.test.ts
+++ b/src/__tests__/AI.test.ts
@@ -1,0 +1,64 @@
+import AI from '@tictactoe/ai/AI';
+import { AIDifficultyLevel } from '@tictactoe/ai/AIDifficultyLevel';
+import Game from '@tictactoe/Game';
+import { Player } from '@tictactoe/Player';
+
+describe('AI', () => {
+    let ai: AI;
+
+    it('should compute display name', () => {
+        expect(new AI().toString()).toBe('game.ai');
+    });
+
+    describe('Minimax algorithm', () => {
+        beforeEach(() => {
+            ai = new AI(AIDifficultyLevel.Unbeatable);
+        });
+
+        it.each`
+            rows                     | score | move
+            ${['x  ', ' o ', '   ']} | ${0}  | ${1}
+            ${['xx ', ' o ', '   ']} | ${-1} | ${2}
+            ${['x  ', 'xo ', '   ']} | ${-1} | ${1}
+            ${['xo ', ' x ', '   ']} | ${-1} | ${2}
+            ${['xo ', ' o ', '   ']} | ${0}  | ${7}
+            ${['xx ', ' o ', ' oo']} | ${-1} | ${2}
+            ${['x  ', '  x', ' oo']} | ${-1} | ${6}
+        `('should compute minimax algorithm with rows $rows', ({ rows, score, move }) => {
+            const game = new Game();
+            game['_currentPlayer'] = Player.First;
+
+            // Construct a fake board
+            rows.forEach((row: string, rowIndex: number) => {
+                [...row].forEach((cell: string, colIndex: number) => {
+                    game.updateBoard(
+                        cell === 'x' ? Player.First : cell === 'o' ? Player.Second : Player.None,
+                        rowIndex * row.length + colIndex
+                    );
+                });
+            });
+
+            const operate = ai.operate(game);
+            expect(operate.score).toBe(score);
+            expect(operate.move).toBe(move);
+        });
+    });
+
+    describe('Randomize algorithm', () => {
+        beforeEach(() => {
+            ai = new AI();
+            ai['randomRate'] = 1;
+        });
+
+        it('should only pick empty cells', () => {
+            const game = new Game();
+            game.updateBoard(Player.First, 0);
+            game.updateBoard(Player.Second, 2);
+            for (let i = 0; i < 50; i++) {
+                const { move } = ai.operate(game);
+                expect(move).toBeDefined();
+                expect([0, 2].includes(move!)).toBeFalsy();
+            }
+        });
+    });
+});

--- a/src/__tests__/AI.test.ts
+++ b/src/__tests__/AI.test.ts
@@ -31,10 +31,13 @@ describe('AI', () => {
             // Construct a fake board
             rows.forEach((row: string, rowIndex: number) => {
                 [...row].forEach((cell: string, colIndex: number) => {
-                    game.updateBoard(
-                        cell === 'x' ? Player.First : cell === 'o' ? Player.Second : Player.None,
-                        rowIndex * row.length + colIndex
-                    );
+                    let player = Player.None;
+                    if (cell === 'x') {
+                        player = Player.First;
+                    } else if (cell === 'o') {
+                        player = Player.Second;
+                    }
+                    game.updateBoard(player, rowIndex * row.length + colIndex);
                 });
             });
 

--- a/src/__tests__/GameBoard.test.ts
+++ b/src/__tests__/GameBoard.test.ts
@@ -5,7 +5,7 @@ import MessagingTunnel from '@bot/messaging/MessagingTunnel';
 import GameStateManager from '@bot/state/GameStateManager';
 import GameConfig from '@config/GameConfig';
 import localize from '@i18n/localize';
-import AI from '@tictactoe/AI';
+import AI from '@tictactoe/ai/AI';
 import Entity from '@tictactoe/Entity';
 import Game from '@tictactoe/Game';
 import { Player } from '@tictactoe/Player';

--- a/src/__tests__/GameBoardBuilder.test.ts
+++ b/src/__tests__/GameBoardBuilder.test.ts
@@ -1,9 +1,9 @@
 import GameBoardBuilder from '@bot/builder/GameBoardBuilder';
 import localize from '@i18n/localize';
-import AI from '@tictactoe/AI';
+import AI from '@tictactoe/ai/AI';
 import { Player } from '@tictactoe/Player';
 
-jest.mock('@tictactoe/AI');
+jest.mock('@tictactoe/ai/AI');
 
 describe('GameBoardBuilder', () => {
     let builder: GameBoardBuilder;

--- a/src/__tests__/GameBoardButtonBuilder.test.ts
+++ b/src/__tests__/GameBoardButtonBuilder.test.ts
@@ -1,10 +1,10 @@
 import GameBoardButtonBuilder from '@bot/builder/GameBoardButtonBuilder';
 import localize from '@i18n/localize';
-import AI from '@tictactoe/AI';
+import AI from '@tictactoe/ai/AI';
 import { Player } from '@tictactoe/Player';
 import { MessageButton } from 'discord.js';
 
-jest.mock('@tictactoe/AI');
+jest.mock('@tictactoe/ai/AI');
 
 describe('GameBoardButtonBuilder', () => {
     let builder: GameBoardButtonBuilder;

--- a/src/__tests__/GameStateManager.test.ts
+++ b/src/__tests__/GameStateManager.test.ts
@@ -5,14 +5,14 @@ import MessagingTunnel from '@bot/messaging/MessagingTunnel';
 import GameStateManager from '@bot/state/GameStateManager';
 import GameStateValidator from '@bot/state/GameStateValidator';
 import TicTacToeBot from '@bot/TicTacToeBot';
-import AI from '@tictactoe/AI';
+import AI from '@tictactoe/ai/AI';
 import Entity from '@tictactoe/Entity';
 import { GuildMember } from 'discord.js';
 
 jest.mock('@bot/entity/DuelRequest');
 jest.mock('@bot/entity/GameBoard');
 jest.mock('@bot/state/GameStateValidator');
-jest.mock('@tictactoe/AI');
+jest.mock('@tictactoe/ai/AI');
 
 describe('GameStateManager', () => {
     const duelRequest = jest.mocked(DuelRequest);

--- a/src/bot/builder/GameBoardBuilder.ts
+++ b/src/bot/builder/GameBoardBuilder.ts
@@ -1,5 +1,5 @@
 import localize from '@i18n/localize';
-import AI from '@tictactoe/AI';
+import AI from '@tictactoe/ai/AI';
 import Entity from '@tictactoe/Entity';
 import { Player } from '@tictactoe/Player';
 import { MessageOptions } from 'discord.js';

--- a/src/bot/entity/GameBoard.ts
+++ b/src/bot/entity/GameBoard.ts
@@ -4,7 +4,7 @@ import MessagingTunnel from '@bot/messaging/MessagingTunnel';
 import GameStateManager from '@bot/state/GameStateManager';
 import GameConfig from '@config/GameConfig';
 import localize from '@i18n/localize';
-import AI from '@tictactoe/AI';
+import AI from '@tictactoe/ai/AI';
 import Entity from '@tictactoe/Entity';
 import Game from '@tictactoe/Game';
 import {

--- a/src/bot/state/GameStateManager.ts
+++ b/src/bot/state/GameStateManager.ts
@@ -3,7 +3,8 @@ import GameBoard from '@bot/entity/GameBoard';
 import MessagingTunnel from '@bot/messaging/MessagingTunnel';
 import GameStateValidator from '@bot/state/GameStateValidator';
 import TicTacToeBot from '@bot/TicTacToeBot';
-import AI from '@tictactoe/AI';
+import AI from '@tictactoe/ai/AI';
+import { AIDifficultyLevel } from '@tictactoe/ai/AIDifficultyLevel';
 import Entity from '@tictactoe/Entity';
 import { GuildMember } from 'discord.js';
 
@@ -96,7 +97,7 @@ export default class GameStateManager {
             const gameboard = new GameBoard(
                 this,
                 tunnel,
-                invited ?? new AI(),
+                invited ?? this.createAI(),
                 this.bot.configuration
             );
 
@@ -130,5 +131,15 @@ export default class GameStateManager {
         }
 
         this.gameboards.splice(this.gameboards.indexOf(gameboard), 1);
+    }
+
+    /**
+     * Creates an AI with the difficulty defined in the configuration.
+     *
+     * @returns AI object
+     */
+    private createAI(): AI {
+        const aiDifficulty = this.bot.configuration.aiDifficulty;
+        return new AI(aiDifficulty ? AIDifficultyLevel[aiDifficulty] : undefined);
     }
 }

--- a/src/config/ConfigProvider.ts
+++ b/src/config/ConfigProvider.ts
@@ -1,4 +1,5 @@
 import Config from '@config/Config';
+import { AIDifficulty } from '@config/GameConfig';
 import fs from 'fs';
 import path from 'path';
 
@@ -24,6 +25,7 @@ export default class ConfigProvider implements Config {
     public requestCooldownTime = 0;
     public simultaneousGames = false;
 
+    public aiDifficulty: AIDifficulty = 'Medium';
     public gameExpireTime = 30;
     public gameBoardReactions = false;
     public gameBoardDelete = false;

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -1,3 +1,5 @@
+export type AIDifficulty = 'Easy' | 'Medium' | 'Hard' | 'Unbeatable';
+
 /**
  * Configuration values to handle a game as wanted.
  *
@@ -5,6 +7,10 @@
  * @since 2.1.0
  */
 export default interface GameConfig {
+    /**
+     * Level of difficulty of the AI.
+     */
+    aiDifficulty?: AIDifficulty;
     /**
      * Expiration time of a player turn.
      */

--- a/src/tictactoe/ai/AI.ts
+++ b/src/tictactoe/ai/AI.ts
@@ -92,23 +92,46 @@ export default class AI implements Entity {
         // Go through all cells
         game.board.forEach((cell, index) => {
             if (cell === Player.None) {
-                game.updateBoard(player, index);
-                const deep = this.minimax(game, depth - 1, getOpponent(player));
-
-                game.updateBoard(Player.None, index);
-                deep.move = index;
-
-                if (type === PlayerComputeType.Computer) {
-                    if (deep.score > best.score) {
-                        best = deep;
-                    }
-                } else {
-                    if (deep.score < best.score) {
-                        best = deep;
-                    }
-                }
+                best = this.minimaxCell(game, depth, player, best, index);
             }
         });
+
+        return best;
+    }
+
+    /**
+     * Process a cell at a specific depth using the minimax algorithm.
+     *
+     * @param game game object
+     * @param depth depth at which the algorithm will be operated
+     * @param player player object
+     * @param best best move object
+     * @param index index of the cell to process
+     * @returns best move object after cell processing
+     */
+    private static minimaxCell(
+        game: Game,
+        depth: number,
+        player: Player,
+        best: AIComputeResult,
+        index: number
+    ): AIComputeResult {
+        game.updateBoard(player, index);
+        const deep = this.minimax(game, depth - 1, getOpponent(player));
+
+        game.updateBoard(Player.None, index);
+        deep.move = index;
+
+        const type = AI.getComputeType(player);
+        if (type === PlayerComputeType.Computer) {
+            if (deep.score > best.score) {
+                best = deep;
+            }
+        } else {
+            if (deep.score < best.score) {
+                best = deep;
+            }
+        }
 
         return best;
     }

--- a/src/tictactoe/ai/AIComputeResult.ts
+++ b/src/tictactoe/ai/AIComputeResult.ts
@@ -1,0 +1,16 @@
+/**
+ * Represents a result of an AI computation.
+ *
+ * @author Utarwyn
+ * @since 2.0.0
+ */
+export interface AIComputeResult {
+    /**
+     * Poosition where the AI has decided to play. Can be empty if none found.
+     */
+    move?: number;
+    /**
+     * Score computed by the algorithm to find the best move to play.
+     */
+    score: number;
+}

--- a/src/tictactoe/ai/AIDifficultyLevel.ts
+++ b/src/tictactoe/ai/AIDifficultyLevel.ts
@@ -1,0 +1,12 @@
+/**
+ * Represents a level of difficulty that the AI can have.
+ *
+ * @author Utarwyn
+ * @since 3.2.0
+ */
+export enum AIDifficultyLevel {
+    Easy = 'Easy',
+    Medium = 'Medium',
+    Hard = 'Hard',
+    Unbeatable = 'Unbeatable'
+}


### PR DESCRIPTION
## Description

A long-awaited feature will be added to the module!
**Levels of difficulty of the AI** 🤖

As I don't know how to properly modify the minimax algorithm to make it less "intelligent", I use a random rate when the AI plays. Given that, sometimes it picks a random empty cell instead of running whole minimax algorithm. I think it's a good starting point to make the bot easier to beat, and I had to move on to a solution I could afford.

> This addition will be available for versions 3 and 4 of the module. 🚀 

## Changes

- Add a new option called "aiDifficulty" which can take a level of difficulty as a string.
Possible values: (**Easy**, **Medium**, **Hard**, **Unbeatable** - as actual)

- Set default difficulty to **Medium**
  *(what do you think of that? by default, the bot will be beatable)*

## Related Issues

Resolves #36
Resolves #333

Any feedbacks?