### PR TITLE
Adapt expiration message to game board delete configuration

### DIFF
--- a/src/__tests__/GameBoard.test.ts
+++ b/src/__tests__/GameBoard.test.ts
@@ -327,9 +327,19 @@ describe('GameBoard', () => {
                 expect(spyUpdate).toHaveBeenCalledTimes(1);
             });
 
-            it('should end game if an error occured', async () => {
+            it('should expire game and keep gameboard if an error occured', async () => {
+                configuration.gameBoardDelete = false;
                 await callCollectorEvent('end', null, 'expiration');
                 expect(game.updateBoard).toHaveBeenCalledTimes(0);
+                expect(tunnel.end).toHaveBeenCalledTimes(0);
+                expect(manager.endGame).toHaveBeenCalledTimes(1);
+            });
+
+            it('should expire game and delete gameboard if an error occured', async () => {
+                configuration.gameBoardDelete = true;
+                await callCollectorEvent('end', null, 'expiration');
+                expect(game.updateBoard).toHaveBeenCalledTimes(0);
+                expect(tunnel.end).toHaveBeenCalledTimes(1);
                 expect(manager.endGame).toHaveBeenCalledTimes(1);
             });
 


### PR DESCRIPTION
## Description
In the current version of the module, the game expiration message systematically replaces the message containing the game board. This is fine when you don't want to keep it, but illogical when you don't want to delete the game board (`gameBoardDelete` is *false*).

So I propose to display the game expiration message in the same place as the winner, if any. It will be more consistent 👍 

#### Here is a preview of how it will looks with `gameBoardDelete` = true (like actual):
![image](https://github.com/utarwyn/discord-tictactoe/assets/9255967/a2cdb3b8-df74-4969-8c01-0ae83a4a76fd)

#### Here is a preview of how it will looks with `gameBoardDelete` = false:
![image](https://github.com/utarwyn/discord-tictactoe/assets/9255967/c4b078b6-f87d-4aed-82c7-c190d27297a5)


🌂Closes #421
🚀 Will be available from v3.x.