### PR TITLE
Add "newGame" event

### DIFF
--- a/src/__tests__/EventHandler.test.ts
+++ b/src/__tests__/EventHandler.test.ts
@@ -9,7 +9,7 @@ describe('EventHandler', () => {
     });
 
     test('should initialize supported events', () => {
-        expect(Array.from(eventHandler.listeners.keys())).toEqual(['win', 'tie']);
+        expect(Array.from(eventHandler.listeners.keys())).toEqual(['newGame', 'win', 'tie']);
     });
 
     test('should register a listener if event exists', () => {

--- a/src/__tests__/GameCommand.test.ts
+++ b/src/__tests__/GameCommand.test.ts
@@ -193,5 +193,12 @@ describe('GameCommand', () => {
                 'game.in-progress'
             );
         });
+
+        test('should reject with the custom error if provided', async () => {
+            jest.spyOn(stateManager, 'createGame').mockRejectedValue(new Error('custom error'));
+            await expect(command['processInvitation'](tunnel, inviter)).rejects.toBe(
+                'custom error'
+            );
+        });
     });
 });

--- a/src/__tests__/GameStateManager.test.ts
+++ b/src/__tests__/GameStateManager.test.ts
@@ -93,6 +93,15 @@ describe('GameStateManager', () => {
             expect(validator.isNewGamePossible).toHaveBeenCalledWith(tunnel, invited);
         });
 
+        it('should reject if emitted event throws an error', async () => {
+            const error = new Error('cannot start the game');
+            jest.spyOn(bot.eventHandler, 'emitEvent').mockImplementation(() => {
+                throw error;
+            });
+            const invited = <GuildMember>{};
+            await expect(manager.createGame(tunnel, invited)).rejects.toEqual(error);
+        });
+
         it('should create a game board and send it into the messaging tunnel', async () => {
             const spyReplyWith = jest.spyOn(tunnel, 'replyWith');
 

--- a/src/__tests__/I18nProvider.test.ts
+++ b/src/__tests__/I18nProvider.test.ts
@@ -32,21 +32,16 @@ describe('I18nProvider', () => {
     });
 
     it.each`
-        data                           | key          | replacements                    | warned   | expected
-        ${{ key: 'fake' }}             | ${'key'}     | ${null}                         | ${false} | ${'fake'}
-        ${{ 'key.awo': '{p1}: {p2}' }} | ${'key.awo'} | ${{ p1: 'test1', p2: 'test2' }} | ${false} | ${'test1: test2'}
-        ${{ key2: 'key2' }}            | ${'key'}     | ${null}                         | ${true}  | ${'key'}
-        ${undefined}                   | ${'my.key'}  | ${null}                         | ${true}  | ${'my.key'}
+        data                           | key          | replacements                    | expected
+        ${{ key: 'fake' }}             | ${'key'}     | ${null}                         | ${'fake'}
+        ${{ 'key.awo': '{p1}: {p2}' }} | ${'key.awo'} | ${{ p1: 'test1', p2: 'test2' }} | ${'test1: test2'}
+        ${{ key2: 'key2' }}            | ${'key'}     | ${null}                         | ${'key'}
+        ${undefined}                   | ${'my.key'}  | ${null}                         | ${'my.key'}
     `(
         'should translate $key with replacements $replacements',
-        ({ data, key, replacements, warned, expected }) => {
-            const spyWarn = jest.spyOn(global.console, 'warn').mockImplementation();
-
+        ({ data, key, replacements, expected }) => {
             provider['localeData'] = data;
-
             expect(provider.__(key, replacements)).toBe(expected);
-            expect(spyWarn).toHaveBeenCalledTimes(warned ? 1 : 0);
-            spyWarn.mockRestore();
         }
     );
 });

--- a/src/bot/EventHandler.ts
+++ b/src/bot/EventHandler.ts
@@ -4,6 +4,7 @@ import Entity from '@tictactoe/Entity';
  * Supported type of events
  */
 export type EventTypes = {
+    newGame: (data: { players: Entity[] }) => void;
     win: (data: { winner: Entity; loser: Entity }) => void;
     tie: (data: { players: Entity[] }) => void;
 };
@@ -26,6 +27,7 @@ export default class EventHandler {
     constructor() {
         this.listeners = new Map();
 
+        this.supportEvent('newGame');
         this.supportEvent('win');
         this.supportEvent('tie');
     }

--- a/src/bot/command/GameCommand.ts
+++ b/src/bot/command/GameCommand.ts
@@ -127,6 +127,6 @@ export default class GameCommand {
         } else {
             handler = this.manager.createGame(tunnel);
         }
-        return handler.catch(() => Promise.reject('game.in-progress'));
+        return handler.catch((err?: Error) => Promise.reject(err?.message ?? 'game.in-progress'));
     }
 }

--- a/src/bot/state/GameStateManager.ts
+++ b/src/bot/state/GameStateManager.ts
@@ -99,6 +99,9 @@ export default class GameStateManager {
                 this.bot.configuration
             );
 
+            // Emit a custom event which can cancel the game creation if throws an error
+            this.bot.eventHandler.emitEvent('newGame', { players: gameboard.entities });
+
             // Register the gameboard in the list
             this.gameboards.push(gameboard);
 

--- a/src/i18n/I18nProvider.ts
+++ b/src/i18n/I18nProvider.ts
@@ -91,7 +91,6 @@ export class I18nProvider {
 
             return message;
         } else {
-            console.warn(`Cannot find language key ${key}. Using key instead.`);
             return key;
         }
     }


### PR DESCRIPTION
## Description

This PR creates a new event in the module called "**newGame**".
It will be triggered right before a game is launched and enables the developer to **check and cancel** its creation if needed.

Examples of use:

- Bet system (take a virtual money before the game starts, and cancel game if player does not have the required amount)
- Statistics system (number of games played per player, etc.)
- Whatever you want 😎 

> This addition will be available for versions 3 and 4 of the module. 🚀 

## Code example

```javascript
const toBet = 5;
const bank = { player_id_1: 6, player_id_2: 34 };

bot.on('newGame', data => {
    const realPlayers = data.players.filter(player => player.id !== 'AI');
    const playerNotEnoughMoney = realPlayers.find(player => bank[player.id] < toBet);
    if (playerNotEnoughMoney != null) {
        throw new Error(`${playerNotEnoughMoney.displayName} does not have enough money to play.`);
    }

    realPlayers.forEach(player => (bank[player.id] -= toBet));
});
```

Example of data object:
```json
{
  "players": [
    {
      "id": "AI",
      "displayName": "the AI"
    },
    {
      "id": "player_id_1",
      "displayName": "Maxime — Utarwyn"
    }
  ]
}
```

## Related Issues

Part of #258 