### PR TITLE
Add an option to display the player's emoji

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -17,5 +17,6 @@
   "gameBoardDisableButtons": false,
   "gameBoardEmbed": false,
   "gameBoardEmojies": [],
+  "gameBoardPlayerEmoji": false,
   "gameBoardReactions": false
 }

--- a/src/__tests__/GameBoard.test.ts
+++ b/src/__tests__/GameBoard.test.ts
@@ -59,6 +59,7 @@ describe('GameBoard', () => {
             withEmbed: jest.fn().mockReturnThis(),
             withEmojies: jest.fn().mockReturnThis(),
             withEndingMessage: jest.fn().mockReturnThis(),
+            withLoadingMessage: jest.fn().mockReturnThis(),
             withEntityPlaying: jest.fn().mockReturnThis(),
             withExpireMessage: jest.fn().mockReturnThis(),
             withTitle: jest.fn().mockReturnThis()
@@ -88,11 +89,27 @@ describe('GameBoard', () => {
             }
         );
 
+        it('should set loading message if reactions are not loaded', () => {
+            gameBoard.content;
+            expect(mockedBuilder.withLoadingMessage).toHaveBeenCalledTimes(1);
+        });
+
         it('should set entity playing if reactions are loaded', () => {
             gameBoard['reactionsLoaded'] = true;
             gameBoard.content;
             expect(mockedBuilder.withEntityPlaying).toHaveBeenCalledTimes(1);
-            expect(mockedBuilder.withEntityPlaying).toHaveBeenCalledWith(tunnel.author);
+            expect(mockedBuilder.withEntityPlaying).toHaveBeenCalledWith(tunnel.author, undefined);
+        });
+
+        it('should set entity playing with an emoji', () => {
+            configuration.gameBoardPlayerEmoji = true;
+            gameBoard['reactionsLoaded'] = true;
+            gameBoard.content;
+            expect(mockedBuilder.withEntityPlaying).toHaveBeenCalledTimes(1);
+            expect(mockedBuilder.withEntityPlaying).toHaveBeenCalledWith(
+                tunnel.author,
+                Player.First
+            );
         });
 
         it('should add an ending message if the game is finished', () => {

--- a/src/__tests__/GameBoardButtonBuilder.test.ts
+++ b/src/__tests__/GameBoardButtonBuilder.test.ts
@@ -59,9 +59,13 @@ describe('GameBoardButtonBuilder', () => {
         expect((options.components![1].components[1] as MessageButton).emoji?.name).toBe('square');
     });
 
+    it('should do nothing when a loading message is added', () => {
+        const options = builder.withLoadingMessage().toMessageOptions();
+        expect(options.content).toBe('');
+    });
+
     it.each`
         entity                        | state
-        ${undefined}                  | ${''}
         ${new AI()}                   | ${':robot: AI is playing, please wait...'}
         ${{ toString: () => 'fake' }} | ${'fake, select your move:'}
     `('should set state based if playing entity is $entity', ({ entity, state }) => {

--- a/src/bot/builder/GameBoardBuilder.ts
+++ b/src/bot/builder/GameBoardBuilder.ts
@@ -70,7 +70,7 @@ export default class GameBoardBuilder {
      * @param player2 second entity to play
      * @returns same instance
      */
-    public withTitle(player1: Entity, player2: Entity): GameBoardBuilder {
+    public withTitle(player1: Entity, player2: Entity): this {
         this.title =
             localize.__('game.title', {
                 player1: player1.displayName,
@@ -87,7 +87,7 @@ export default class GameBoardBuilder {
      * @param none emoji used for an empty cell
      * @returns same instance
      */
-    public withEmojies(first: string, second: string, none?: string): GameBoardBuilder {
+    public withEmojies(first: string, second: string, none?: string): this {
         this.emojies = [none ?? this.emojies[0], first, second];
         return this;
     }
@@ -99,7 +99,7 @@ export default class GameBoardBuilder {
      * @param board game board data
      * @returns same instance
      */
-    public withBoard(boardSize: number, board: Player[]): GameBoardBuilder {
+    public withBoard(boardSize: number, board: Player[]): this {
         this.boardSize = boardSize;
         this.boardData = board;
         return this;
@@ -122,7 +122,7 @@ export default class GameBoardBuilder {
      * @param emojiIndex index of the emoji to display next to entity name
      * @returns same instance
      */
-    public withEntityPlaying(entity: Entity, emojiIndex?: number): GameBoardBuilder {
+    public withEntityPlaying(entity: Entity, emojiIndex?: number): this {
         this.stateEntity = { name: entity.toString(), emojiIndex: emojiIndex };
         this.stateKey = entity instanceof AI ? 'game.waiting-ai' : 'game.action';
         return this;
@@ -134,7 +134,7 @@ export default class GameBoardBuilder {
      * @param winner winning entity. If undefined: display tie message
      * @returns same instance
      */
-    public withEndingMessage(winner?: Entity): GameBoardBuilder {
+    public withEndingMessage(winner?: Entity): this {
         if (winner) {
             this.stateKey = 'game.win';
             this.stateEntity = { name: winner.toString() };
@@ -149,7 +149,7 @@ export default class GameBoardBuilder {
      *
      * @returns same instance
      */
-    public withExpireMessage(): GameBoardBuilder {
+    public withExpireMessage(): this {
         this.stateKey = 'game.expire';
         return this;
     }
@@ -160,7 +160,7 @@ export default class GameBoardBuilder {
      * @param embedColor color of the embed
      * @returns same instance
      */
-    public withEmbed(embedColor: EmbedColor): GameBoardBuilder {
+    public withEmbed(embedColor: EmbedColor): this {
         this.embedColor = embedColor;
         return this;
     }

--- a/src/bot/builder/GameBoardButtonBuilder.ts
+++ b/src/bot/builder/GameBoardButtonBuilder.ts
@@ -61,13 +61,9 @@ export default class GameBoardButtonBuilder extends GameBoardBuilder {
      * @inheritdoc
      * @override
      */
-    override withEntityPlaying(entity?: Entity): GameBoardBuilder {
-        // Do not display state if game is loading
-        if (entity) {
-            return super.withEntityPlaying(entity);
-        } else {
-            return this;
-        }
+    override withLoadingMessage(): this {
+        // there is no need to display loading message
+        return this;
     }
 
     /**
@@ -94,11 +90,12 @@ export default class GameBoardButtonBuilder extends GameBoardBuilder {
      * @override
      */
     override toMessageOptions(): MessageOptions {
+        const state = this.generateState();
         return {
             embeds: this.embedColor
-                ? [{ title: this.title, description: this.state, color: this.embedColor }]
+                ? [{ title: this.title, description: state, color: this.embedColor }]
                 : [],
-            content: !this.embedColor ? this.title + this.state : undefined,
+            content: !this.embedColor ? this.title + state : undefined,
             components: [...Array(this.boardSize).keys()].map(row =>
                 new MessageActionRow().addComponents(
                     [...Array(this.boardSize).keys()].map(col => this.createButton(row, col))

--- a/src/bot/builder/GameBoardButtonBuilder.ts
+++ b/src/bot/builder/GameBoardButtonBuilder.ts
@@ -52,7 +52,7 @@ export default class GameBoardButtonBuilder extends GameBoardBuilder {
      *
      * @returns same instance
      */
-    public withButtonsDisabledAfterUse(): GameBoardBuilder {
+    public withButtonsDisabledAfterUse(): this {
         this.disableButtonsAfterUsed = true;
         return this;
     }
@@ -70,7 +70,7 @@ export default class GameBoardButtonBuilder extends GameBoardBuilder {
      * @inheritdoc
      * @override
      */
-    override withEndingMessage(winner?: Entity): GameBoardBuilder {
+    override withEndingMessage(winner?: Entity): this {
         this.gameEnded = true;
         return super.withEndingMessage(winner);
     }
@@ -79,7 +79,7 @@ export default class GameBoardButtonBuilder extends GameBoardBuilder {
      * @inheritdoc
      * @override
      */
-    override withEmojies(first: string, second: string, none?: string): GameBoardBuilder {
+    override withEmojies(first: string, second: string, none?: string): this {
         this.customEmojies = true;
         this.customIdleEmoji = none != null;
         return super.withEmojies(first, second, none);

--- a/src/bot/entity/GameBoard.ts
+++ b/src/bot/entity/GameBoard.ts
@@ -96,10 +96,17 @@ export default class GameBoard {
 
         builder
             .withTitle(this.entities[0], this.entities[1])
-            .withBoard(this.game.boardSize, this.game.board)
-            .withEntityPlaying(
-                this.reactionsLoaded ? this.getEntity(this.game.currentPlayer) : undefined
+            .withBoard(this.game.boardSize, this.game.board);
+
+        const currentEntity = this.getEntity(this.game.currentPlayer);
+        if (this.reactionsLoaded && currentEntity != null) {
+            builder.withEntityPlaying(
+                currentEntity,
+                this.configuration.gameBoardPlayerEmoji ? this.game.currentPlayer : undefined
             );
+        } else {
+            builder.withLoadingMessage();
+        }
 
         if (this.expired) {
             builder.withExpireMessage();

--- a/src/config/ConfigProvider.ts
+++ b/src/config/ConfigProvider.ts
@@ -31,6 +31,7 @@ export default class ConfigProvider implements Config {
     public gameBoardDisableButtons = false;
     public gameBoardEmbed = false;
     public gameBoardEmojies = [];
+    public gameBoardPlayerEmoji = false;
     public gameBoardReactions = false;
 
     [key: string]: any;

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -36,6 +36,10 @@ export default interface GameConfig {
      */
     gameBoardEmojies?: string[];
     /**
+     * Should display current player's emoji next to its name.
+     */
+    gameBoardPlayerEmoji?: boolean;
+    /**
      * Interact with game board using reactions instead of buttons.
      */
     gameBoardReactions?: boolean;


### PR DESCRIPTION
## Description

This PR creates a new option called `gameBoardPlayerEmoji` for displaying the player's emoji after its name in the gameboard state.

#### Here is a preview of how it will looks with `gameBoardPlayerEmoji` = false (current behavior):
![image](https://github.com/utarwyn/discord-tictactoe/assets/9255967/ebaaad68-5eb7-4e1c-b58c-402b45ce6125)

#### Here is a preview of how it will looks with `gameBoardPlayerEmoji` = true:
![image](https://github.com/utarwyn/discord-tictactoe/assets/9255967/602700af-d281-4b2e-ae18-2073c0015efd)

🌂Closes #436
🚀 Will be available from v3.x.