### PR TITLE
Add a method to register custom message providers

### DIFF
--- a/src/__tests__/I18nProvider.test.ts
+++ b/src/__tests__/I18nProvider.test.ts
@@ -44,4 +44,17 @@ describe('I18nProvider', () => {
             expect(provider.__(key, replacements)).toBe(expected);
         }
     );
+
+    describe('Dynamic message providers', () => {
+        it('should register and use a message provider of an existing key', () => {
+            provider['localeData'] = { 'game.load': 'default message' };
+            const message = 'Another game loading message';
+            provider.addProvider('game.load', () => message);
+            expect(provider.__('game.load')).toBe(message);
+        });
+
+        it('should throw an error if the key does not exist', () => {
+            expect(() => provider.addProvider('unknown_key', () => 'hello world')).toThrow();
+        });
+    });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -100,4 +100,11 @@ describe('TicTacToe', () => {
         expect(eventHandler.registerListener).toHaveBeenCalledTimes(1);
         expect(eventHandler.registerListener).toHaveBeenCalledWith('tie', listener);
     });
+
+    test('should call addProvider from localize', () => {
+        const messageProvider = () => 'my message';
+        tictactoe.addMessageProvider('game.load', messageProvider);
+        expect(localize.addProvider).toHaveBeenCalledTimes(1);
+        expect(localize.addProvider).toHaveBeenCalledWith('game.load', messageProvider);
+    });
 });

--- a/src/__tests__/localize.test.ts
+++ b/src/__tests__/localize.test.ts
@@ -1,0 +1,29 @@
+const provider = { loadFromLocale: jest.fn(), __: jest.fn(), addProvider: jest.fn() };
+
+jest.mock('@i18n/I18nProvider', () => ({
+    I18nProvider: jest.fn().mockImplementation(() => provider)
+}));
+
+import localize from '@i18n/localize';
+
+describe('Localize', () => {
+    it('should call loadFromLocale from the provider', () => {
+        localize.loadFromLocale('fr');
+        expect(provider.loadFromLocale).toHaveBeenCalledTimes(1);
+        expect(provider.loadFromLocale).toHaveBeenCalledWith('fr');
+    });
+
+    it('should call __ from the provider', () => {
+        const replacements = { player: 'utarwyn' };
+        localize.__('key', replacements);
+        expect(provider.__).toHaveBeenCalledTimes(1);
+        expect(provider.__).toHaveBeenCalledWith('key', replacements);
+    });
+
+    it('should call addProvider from the provider', () => {
+        const messageProvider = () => 'custom message';
+        localize.addProvider('key', messageProvider);
+        expect(provider.addProvider).toHaveBeenCalledTimes(1);
+        expect(provider.addProvider).toHaveBeenCalledWith('key', messageProvider);
+    });
+});

--- a/src/i18n/I18nProvider.ts
+++ b/src/i18n/I18nProvider.ts
@@ -1,15 +1,6 @@
+import { MessageProvider, Replacements } from '@i18n/types';
 import fs from 'fs';
 import path from 'path';
-
-/**
- * Represents a collection of replacements when translating a text.
- */
-export type Replacements = { [key: string]: string | number | string[] };
-
-/**
- * Represents a message provider added programmatically.
- */
-export type MessageProvider = () => string;
 
 /**
  * Default implementation to translate messages.

--- a/src/i18n/localize.ts
+++ b/src/i18n/localize.ts
@@ -1,8 +1,10 @@
-import { I18nProvider, Replacements } from '@i18n/I18nProvider';
+import { I18nProvider, MessageProvider, Replacements } from '@i18n/I18nProvider';
 
 const provider = new I18nProvider();
 
 const loadFromLocale = (locale?: string): void => provider.loadFromLocale(locale);
 const __ = (id: string, replacements?: Replacements): string => provider.__(id, replacements);
+const addProvider = (id: string, messageProvider: MessageProvider): void =>
+    provider.addProvider(id, messageProvider);
 
-export default { loadFromLocale, __ };
+export default { loadFromLocale, __, addProvider };

--- a/src/i18n/localize.ts
+++ b/src/i18n/localize.ts
@@ -1,4 +1,5 @@
-import { I18nProvider, MessageProvider, Replacements } from '@i18n/I18nProvider';
+import { I18nProvider } from '@i18n/I18nProvider';
+import { MessageProvider, Replacements } from '@i18n/types';
 
 const provider = new I18nProvider();
 

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents a collection of replacements when translating a text.
+ */
+export type Replacements = { [key: string]: string | number | string[] };
+
+/**
+ * Represents a message provider added programmatically.
+ */
+export type MessageProvider = () => string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import TicTacToeBot from '@bot/TicTacToeBot';
 import Config from '@config/Config';
 import localize from '@i18n/localize';
 import { Client, CommandInteraction, Intents, Message } from 'discord.js';
+import { MessageProvider } from '@i18n/I18nProvider';
 
 /**
  * Controls all interactions between modules of the bot.
@@ -102,6 +103,17 @@ class TicTacToe {
         listener: V
     ): void {
         this.eventHandler.registerListener(eventName, listener);
+    }
+
+    /**
+     * Adds a message provider for a given key.
+     * Key must exist, otherwise an error will be thrown.
+     *
+     * @param key key corresponding to the added provider
+     * @param provider function that dynamically supplies the message
+     */
+    public addMessageProvider(key: string, provider: MessageProvider): void {
+        localize.addProvider(key, provider);
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import EventHandler, { EventTypes } from '@bot/EventHandler';
 import TicTacToeBot from '@bot/TicTacToeBot';
 import Config from '@config/Config';
 import localize from '@i18n/localize';
+import { MessageProvider } from '@i18n/types';
 import { Client, CommandInteraction, Intents, Message } from 'discord.js';
-import { MessageProvider } from '@i18n/I18nProvider';
 
 /**
  * Controls all interactions between modules of the bot.


### PR DESCRIPTION
## Description

This PR adds a method to register a message provider programmatically.
You can use it to display dynamic values that may change over time.

Few examples:
- Display a dynamic bet to play a game
- Display the date/hour
- Display your own statistics

> ℹ️ You can use the default variables in the provided messages

## Usage example

You can use it this way:
```javascript
const bot = new TicTacToe({ language: 'en' });
bot.addMessageProvider('game.title', () => 'Current date is ' + new Date());
```

Signature of the method (in TypeScript) is:
```typescript
/**
 * Adds a message provider for a given key.
 * Key must exist, otherwise an error will be thrown.
 *
 * @param key key corresponding to the added provider
 * @param provider function that dynamically supplies the message
 */
addMessageProvider(key: string, provider: () => string): void;
```

🌂Closes #258
🚀 Will be available from v3.x.